### PR TITLE
refactor: Adjust for Behaviors#89

### DIFF
--- a/assets/behaviors/visitor.behavior
+++ b/assets/behaviors/visitor.behavior
@@ -1,7 +1,6 @@
 {
   sequence : [
     set_target_to_visit_block,
-    ensure_target_present,
     {
       animation : {
         play: "engine:Walk.animationPool",

--- a/module.txt
+++ b/module.txt
@@ -43,10 +43,6 @@
             "minVersion": "1.1.0"
         },
         {
-            "id": "Pathfinding",
-            "minVersion": "1.0.0"
-        },
-        {
             "id": "StructureTemplates",
             "minVersion": "1.0.0"
         },

--- a/src/main/java/org/terasology/gookeeper/actions/SetTargetToVisitBlockAction.java
+++ b/src/main/java/org/terasology/gookeeper/actions/SetTargetToVisitBlockAction.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.gookeeper.actions;
 
+import org.joml.RoundingMode;
 import org.joml.Vector3f;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.logic.behavior.BehaviorAction;
@@ -30,11 +31,12 @@ public class SetTargetToVisitBlockAction extends BaseAction {
         MinionMoveComponent moveComponent = actor.getComponent(MinionMoveComponent.class);
         VisitorComponent visitorComponent = actor.getComponent(VisitorComponent.class);
 
-        if (moveComponent.currentBlock != null && visitorComponent.pensToVisit.size() > 0) {
+        if (visitorComponent.pensToVisit.size() > 0) {
             int penIndex = getRandomPenIndex(visitorComponent);
             EntityRef penToVisit = visitorComponent.pensToVisit.get(penIndex);
 
-            moveComponent.target = penToVisit.getComponent(LocationComponent.class).getWorldPosition(new Vector3f());
+            Vector3f worldPosition = penToVisit.getComponent(LocationComponent.class).getWorldPosition(new Vector3f());
+            moveComponent.target.set(worldPosition, RoundingMode.FLOOR);
             actor.save(moveComponent);
         } else {
             return BehaviorState.FAILURE;

--- a/src/main/java/org/terasology/gookeeper/actions/SetTargetToVisitBlockAction.java
+++ b/src/main/java/org/terasology/gookeeper/actions/SetTargetToVisitBlockAction.java
@@ -1,4 +1,4 @@
-// Copyright 2021 The Terasology Foundation
+// Copyright 2022 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.gookeeper.actions;
 
@@ -10,19 +10,14 @@ import org.terasology.engine.logic.behavior.core.Actor;
 import org.terasology.engine.logic.behavior.core.BaseAction;
 import org.terasology.engine.logic.behavior.core.BehaviorState;
 import org.terasology.engine.logic.location.LocationComponent;
-import org.terasology.engine.registry.In;
 import org.terasology.gookeeper.component.VisitBlockComponent;
 import org.terasology.gookeeper.component.VisitorComponent;
 import org.terasology.module.behaviors.components.MinionMoveComponent;
-import org.terasology.pathfinding.componentSystem.PathfinderSystem;
 
 import java.util.Random;
 
 @BehaviorAction(name = "set_target_to_visit_block")
 public class SetTargetToVisitBlockAction extends BaseAction {
-
-    @In
-    private PathfinderSystem pathfinderSystem;
 
     private transient Random random = new Random();
 


### PR DESCRIPTION
Adjust for https://github.com/Terasology/Behaviors/pull/89

A few components and systems have changed due to the switch from Pathfinding to FlexiblePathfinding.

This PR adjusts the breaking pieces of code to the best of my knowledge. Typical changes for this migration are:

- `MinionMoveComponent#target` is now a `Vector3i` and no longer a `Vector3f` (fixed by rounding)
- `MinionMoveComponent#type` was removed (no longer required, just remove references)
